### PR TITLE
remove apt-transport-https as dependency

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -3,7 +3,6 @@
 - name: install dependencies
   ansible.builtin.apt:
     name:
-      - apt-transport-https
       - ca-certificates
       - gnupg2
     state: present


### PR DESCRIPTION
apt-transport-https has been a dummy package since Debian 10 and Ubuntu 18.04